### PR TITLE
Bump the "node" image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM node:10.5.0-slim
-RUN npm install -g json-server curl
+FROM node:12.11.1-slim
+RUN npm install -g json-server
 
 ADD run.sh default.json /
 ENTRYPOINT ["bash", "/run.sh"]


### PR DESCRIPTION
Bump to `12.11.1-slim` to include a newer version of curl which supports the `--path-as-is` param used by Cilium CI tests (json-mock is going to be used by the tests introduced in https://github.com/cilium/cilium/pull/9399).

Also, do not explicitly install curl, as it is installed by default.