### PR TITLE
Bind server to ANY address

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SERVER_ARGS="--host 0.0.0.0 $@"
+SERVER_ARGS="--host '' $@"
 
 if [ ! -z "$PORT" ]; then
         SERVER_ARGS="$SERVER_ARGS --port $PORT"


### PR DESCRIPTION
On dual-stack setups, this will allow both IPv4 and IPv6 peers to
connect to the server.

Signed-off-by: Sebastian Wicki <gandro@gmx.net>