### PR TITLE
Upgrade to latest minor version of Debian Slim and Node 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
-FROM node:12.11.1-slim
-RUN npm install -g json-server
+FROM node:12.21.0-slim
+RUN npm install -g json-server \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y curl \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 ADD run.sh default.json /
 ENTRYPOINT ["bash", "/run.sh"]


### PR DESCRIPTION
Closes #3.

The latest base image does not include curl by default, so to allow this to continue to work with the connectivity-check, curl is now installed explicitly.