### PR TITLE
Fix host value parser

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -14,4 +14,4 @@ else
         SERVER_ARGS="$SERVER_ARGS --watch /default.json"
 fi
 
-json-server $SERVER_ARGS
+sh -c "json-server $SERVER_ARGS"


### PR DESCRIPTION
### Issue

There is `getaddrinfo ENOTFOUND ''` issue with the latest docker images from docker.io as per below.

```
$ docker pull docker.io/cilium/json-mock:latest 
latest: Pulling from cilium/json-mock
Digest: sha256:1ae01da07ae34ca21bf805e4a4d57904f69ccdb8c0b44f232e444937ff6602e3
Status: Image is up to date for cilium/json-mock:latest
docker.io/cilium/json-mock:latest

$ docker run -it docker.io/cilium/json-mock:latest                               

  \{^_^}/ hi!

  Loading /default.json
  Done

  Resources
  http://'':80/private
  http://'':80/public

  Home
  http://'':80

  Type s + enter at any time to create a snapshot of the database
  Watching...

Some error occurred Error: getaddrinfo ENOTFOUND ''
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (node:dns:69:26) {
  errno: -3008,
  code: 'ENOTFOUND',
  syscall: 'getaddrinfo',
  hostname: "''"
}
```

### Changes

This commit is to wrap json-server command with sh -c commmand to
avoid any parsing issue, which might cause ENOTFOUND while starting
http server.

Signed-off-by: Tam Mach <sayboras@yahoo.com>

###  Testing

Testing was done locally with local docker image build

<details>

```
$ docker image ls quay.io/cilium/json-mock
REPOSITORY                 TAG       IMAGE ID       CREATED          SIZE
quay.io/cilium/json-mock   latest    64170794a2e1   10 minutes ago   211MB
quay.io/cilium/json-mock   <none>    9be77b56e17e   8 months ago     204MB

$ docker run -it quay.io/cilium/json-mock:latest                          

  \{^_^}/ hi!

  Loading /default.json
  Done

  Resources
  http://:80/private
  http://:80/public

  Home
  http://:80

  Type s + enter at any time to create a snapshot of the database
  Watching...

```

</details>