### PR TITLE
Upgrade base image to node 18.0.0-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with
 # TARGETARCH
-FROM docker.io/library/node:16.0.0-slim@sha256:2cc239701e22ed59a2c918f4ba3625a3516b461010b5ce252efdd75e51e2b28b
+FROM docker.io/library/node:18.0.0-slim@sha256:1bf5fec10be761b93909d1d3d1e6929b529284e322d6c5fa6cb304e3fb60e759
 RUN npm install -g json-server \
     && apt-get update \
     && apt-get upgrade -y \


### PR DESCRIPTION
This PR upgrades the base image used here to `18.0.0-slim` which is built off of Debian 11 Bullseye. The current image is based off Debian 10 which likes to trigger some compliance scans. 