### PR TITLE
Add /auth-header-required endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,6 @@ RUN npm install -g json-server \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ADD run.sh default.json /
+ADD run.sh default.json auth-header.js /
 ENTRYPOINT ["bash", "/run.sh"]
 CMD []

--- a/auth-header.js
+++ b/auth-header.js
@@ -1,0 +1,10 @@
+module.exports = (req, res, next) => {
+    if (req.path.indexOf("/auth-header-required") === 0) {
+        if (req.get("Authorization") !== "Bearer 123456") {
+            res.status(401).send('Invalid Authorization header, try setting it to "Bearer 123456"')
+            return
+        }
+    }
+    
+    next()
+}

--- a/default.json
+++ b/default.json
@@ -4,5 +4,8 @@
   ],
   "public": [
     { "id": 1, "body": "public information" }
+  ],
+  "auth-header-required": [
+    { "id": 1, "body": "super secret information" }
   ]
 }

--- a/run.sh
+++ b/run.sh
@@ -14,4 +14,10 @@ else
         SERVER_ARGS="$SERVER_ARGS --watch /default.json"
 fi
 
+if [ ! -z "$MIDDLEWARE" ]; then
+        SERVER_ARGS="$SERVER_ARGS --middlewares $FILE"
+else
+        SERVER_ARGS="$SERVER_ARGS --middlewares /auth-header.js"
+fi
+
 sh -c "json-server $SERVER_ARGS"


### PR DESCRIPTION
This adds a new testpoint called auth-header-required. This endpoint will only return 200 is a specific header is set. This then can be used to test Cilium's ability to add remove or replace headers in HTTP requests.

This PR came out of an effort to make the changes inside https://github.com/cilium/cilium/issues/24020 testable in the GitHub Actions CI.