### PR TITLE
Dockerfile: ensure json-server terminates on SIGTERM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM docker.io/library/node:21.3.0-slim@sha256:8d66ff8ac7f7053d707de87bc86ebfe8b
 RUN npm install -g json-server \
     && apt-get update \
     && apt-get upgrade -y \
-    && apt-get install -y curl iproute2 \
+    && apt-get install -y tini curl iproute2 \
     && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SERVER_ARGS="--host '' $@"
+SERVER_ARGS="$@"
 
 if [ ! -z "$PORT" ]; then
         SERVER_ARGS="$SERVER_ARGS --port $PORT"
@@ -20,4 +20,4 @@ else
         SERVER_ARGS="$SERVER_ARGS --middlewares /middleware.js"
 fi
 
-sh -c "json-server $SERVER_ARGS"
+exec /usr/bin/tini -- /usr/local/bin/json-server --host "" $SERVER_ARGS


### PR DESCRIPTION
Ensure that the json-server process terminates upon reception of the SIGTERM signal, so that the pod doesn't remain in terminating status for 30 seconds (the default grace period) when deleted. This fix involves two changes:

* Run exec at the end of the run.sh script, instead of shelling out, so that the callee gets PID 1;
* Wrap the json-server executable with the "tini" lightweight init system, as apparently node doesn't terminate upon SIGTERM when running as PID 1.