### PR TITLE
Dockerfile: pin json-server version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # Represents the plataform where the build is happening, do not mix with
 # TARGETARCH
 FROM docker.io/library/node:21.5.0-slim@sha256:c88704924204ee6d4e9da02275a8fd27355502f7177e4175cd0d3a4375a9c9c8
-RUN npm install -g json-server \
+RUN npm install -g json-server@v0.17.4 \
     && apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y tini curl iproute2 \


### PR DESCRIPTION
New v1.0.0-alpha.* versions have been recently released, which introduce breaking changes. Let's pin the library to the latest stable version for the moment, to ensure reproducible builds.