### PR TITLE
Dockerfile: add dnsutils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM docker.io/library/node:23.9.0-slim@sha256:dcacc1ee3b03a497c2096b0084d3a67b8
 RUN npm install -g json-server@v0.17.4 \
     && apt-get update \
     && apt-get upgrade -y \
-    && apt-get install -y tini curl iproute2 \
+    && apt-get install -y tini curl iproute2 dnsutils \
     && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Add dnsutils package to check DNS answers with tools such as dig. This is especially useful when showcasing DNS integration in a clustermesh scenario.