### PR TITLE
gh: switch from ubuntu 20.04 to 24.04

### DIFF
--- a/.github/workflows/image-prs.yaml
+++ b/.github/workflows/image-prs.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   build-and-push-prs:
     if: ${{ github.repository == 'cilium/json-mock' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         include:
@@ -101,7 +101,7 @@ jobs:
   image-digests:
     if: ${{ github.repository == 'cilium/json-mock' }}
     name: Display Digests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: build-and-push-prs
     steps:
       - name: Downloading Image Digests

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -10,7 +10,7 @@ jobs:
   build-and-push:
     if: ${{ github.repository == 'cilium/json-mock' }}
     environment: release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         include:
@@ -76,7 +76,7 @@ jobs:
   image-digests:
     if: ${{ github.repository == 'cilium/json-mock' }}
     name: Display Digests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: build-and-push
     steps:
       - name: Downloading Image Digests


### PR DESCRIPTION
20.04 runners are EOL:
https://github.com/actions/runner-images/issues/11101