### PR TITLE
json-server: increase keepalive timeout from 5s to 65s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,18 @@ RUN npm install -g json-server@v0.17.4 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Patch and increase node.js default keep alive timeout of 5s to 65s.
+#
+# Background: Envoy default upstream cluster idle timeout is 60s. If Envoy acts as the "client", this can lead
+# race condition where the backend might close TCP connections with a TCP reset (RST) while Envoy wants to use
+# that connection (-> HTTP 503). Therefore it's recommended that Envoys keepalive timeout is less than the
+# keepalive timeout of the backend.
+#
+# See https://nodejs.org/api/http.html#http_server_keepalivetimeout
+# See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-idle-timeout
+RUN sed -i "/^  var server = http.createServer(this);/a \  server.keepAliveTimeout = 65000;" /usr/local/lib/node_modules/json-server/node_modules/express/lib/application.js \
+    && grep "keepAliveTimeout" /usr/local/lib/node_modules/json-server/node_modules/express/lib/application.js
+
 ADD run.sh default.json middleware.js /
 ENTRYPOINT ["bash", "/run.sh"]
 CMD []


### PR DESCRIPTION
This commit patches and increases node.js default keep alive timeout of 5s to 65s. Unfortunately it doesn't seem to be possible to configure this properly, neither `json-server` nor `express` provide this option.

Background: Envoy default upstream cluster idle timeout is 60s. If Envoy acts as the "client", this can lead race condition where the backend might close TCP connections with a TCP reset (RST) while Envoy wants to use that connection (-> HTTP 503). Therefore it's recommended that Envoys keepalive timeout is less than the keepalive timeout of the backend.

This is also the recommendation of most cloud loadbalancers.

See https://nodejs.org/api/http.html#http_server_keepalivetimeout 
See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-idle-timeout

Related issue: https://github.com/cilium/cilium/issues/39472