### PR TITLE
Add hostname route to middleware

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -10,6 +10,7 @@ module.exports = (req, res, next) => {
 
     if (req.path.indexOf("/client-ip") === 0) {
         res.json({ "client-ip": req.connection.remoteAddress });
+        return
     }
 
     if (req.path.indexOf("/hostname") === 0) {

--- a/middleware.js
+++ b/middleware.js
@@ -1,3 +1,5 @@
+const os = require("os")
+
 module.exports = (req, res, next) => {
     if (req.path.indexOf("/auth-header-required") === 0) {
         if (req.get("Authorization") !== "Bearer 123456") {
@@ -8,6 +10,11 @@ module.exports = (req, res, next) => {
 
     if (req.path.indexOf("/client-ip") === 0) {
         res.json({ "client-ip": req.connection.remoteAddress });
+    }
+
+    if (req.path.indexOf("/hostname") === 0) {
+        res.json({ hostname: os.hostname() })
+        return
     }
 
     next()


### PR DESCRIPTION
It returns the hostname of the server. For instance:

```
$ curl --silent localhost:80/hostname

{
  "hostname": "foo"
}
```