### PR TITLE
run: Omit '--watch' from startup

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -9,9 +9,9 @@ else
 fi
 
 if [ ! -z "$FILE" ]; then
-        SERVER_ARGS="$SERVER_ARGS --watch $FILE"
+        SERVER_ARGS="$SERVER_ARGS $FILE"
 else
-        SERVER_ARGS="$SERVER_ARGS --watch /default.json"
+        SERVER_ARGS="$SERVER_ARGS /default.json"
 fi
 
 if [ ! -z "$MIDDLEWARE" ]; then


### PR DESCRIPTION
Passing the `--watch` option causes the HTTP listener restarts under parallel POST requests, making the listener unavailable for brief periods, during which the incoming connections get reset (TCP RST). When Envoy upstream connections get reset like this, HTTP status 503 is reported to the HTTP client at the source pod, as seen in Cilium CI when sending parallel POST requests via Envoy:
```
  ❌ command "curl --silent --fail --show-error --connect-timeout 2 --max-time 10 -6 --parallel --parallel-immediate -w %{local_ip}:%{local_port} -> %{remote_ip}:%{remote_port} = %{response_code}\n --output /dev/null -X POST http://[fd00:10:244:1::c17f]:8080/private http://[fd00:10:244:1::c17f]:8080/private http://[fd00:10:244:1::c17f]:8080/private" failed: command failed (pod=cilium-test-2/client2-78bbbfb455-b47fk, container=client2): command terminated with exit code 22
  ℹ️  curl stdout:
  fd00:10:244:1::cdfa:38402 -> fd00:10:244:1::c17f:8080 = 503
fd00:10:244:1::cdfa:38404 -> fd00:10:244:1::c17f:8080 = 503 fd00:10:244:1::cdfa:38420 -> fd00:10:244:1::c17f:8080 = 503
  ℹ️  curl stderr:
  curl: (22) The requested URL returned error: 503
curl: (22) The requested URL returned error: 503
curl: (22) The requested URL returned error: 503
```
The `--watch` option is only needed when the file can be modified by another process, which is not the case when using cilium/json-mock image for Cilium testing, so it should be safe to omit the `--watch` option. When running without the `--watch` option, the HTTP listener does not get restarted and parallel POST requests succeed as expected.

Reproduction:
```
$ docker run --rm -d --name json-mock-watch-repro \
  -p 18080:8080 -e PORT=8080 quay.io/cilium/json-mock:v1.4.0

$ for i in $(seq 1 100); do \
  curl --silent --fail --show-error \
  --connect-timeout 1 --max-time 3 \
  --parallel --parallel-immediate \
  -X POST \
  http://127.0.0.1:18080/public \
  http://127.0.0.1:18080/public \
  http://127.0.0.1:18080/public \
  >/dev/null || echo "failed iteration $i"; done
```
This quickly reproduces these failures, and the docker container logs show repeated messages like:
```
/default.json has changed, reloading...

  Loading /default.json
  Loading /middleware.js
  Done
```
When running without the `--watch` option the curl loop produces no failures.